### PR TITLE
[NCL-6910] Fix cleanup generic non-hosted repos after promotion

### DIFF
--- a/src/main/java/org/jboss/pnc/repositorydriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Driver.java
@@ -704,10 +704,10 @@ public class Driver {
                     if (remoteName != null) {
                         other = new StoreKey(genericRepo.getPackageType(), StoreType.remote, remoteName);
                     }
-                } else if (genericRepo.getType() == StoreType.group) {
-                    String remoteName = getGenericRemoteName(genericRepo.getName());
-                    if (remoteName != null) {
-                        other = new StoreKey(genericRepo.getPackageType(), StoreType.remote, remoteName);
+                } else if (genericRepo.getType() == StoreType.remote) {
+                    String groupName = getGenericGroupName(genericRepo.getName());
+                    if (groupName != null) {
+                        other = new StoreKey(genericRepo.getPackageType(), StoreType.group, groupName);
                     }
                 } else {
                     logger.error("Unexpected store type in " + genericRepo + " which should be cleaned. Skipping.");


### PR DESCRIPTION
Fix too much copy-pasting which caused that the remote generic-http repo was not accepted as a valid source.