### PR TITLE
[NCL-7238] Handle maven urls with no extension

### DIFF
--- a/src/main/java/org/jboss/pnc/repositorydriver/TrackingReportProcessor.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/TrackingReportProcessor.java
@@ -59,6 +59,9 @@ public class TrackingReportProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(TrackingReportProcessor.class);
 
+    /** NCL-7238: Add this extension to parse for maven urls with no extensions */
+    public final static String MAVEN_SUBSTITUTE_EXTENSION = ".empty";
+
     @Inject
     ArtifactFilter artifactFilter;
 
@@ -284,6 +287,13 @@ public class TrackingReportProcessor {
         switch (transfer.getStoreKey().getPackageType()) {
             case MAVEN_PKG_KEY:
                 ArtifactPathInfo pathInfo = ArtifactPathInfo.parse(transfer.getPath());
+
+                if (pathInfo == null) {
+                    // NCL-7238: handle cases where url has no file extension. we add the extension
+                    // MAVEN_SUBSTITUTE_EXTENSION and see if that helps to parse the pathInfo. Otherwise this causes
+                    // nasty artifact duplicates
+                    pathInfo = ArtifactPathInfo.parse(transfer.getPath() + MAVEN_SUBSTITUTE_EXTENSION);
+                }
                 if (pathInfo != null) {
                     ArtifactRef aref = new SimpleArtifactRef(
                             pathInfo.getProjectId(),
@@ -337,6 +347,12 @@ public class TrackingReportProcessor {
                 case MAVEN_PKG_KEY:
 
                     ArtifactPathInfo pathInfo = ArtifactPathInfo.parse(transfer.getPath());
+                    if (pathInfo == null) {
+                        // NCL-7238: handle cases where url has no file extension. we add the extension
+                        // MAVEN_SUBSTITUTE_EXTENSION and see if that helps to parse the pathInfo. Otherwise this causes
+                        // nasty artifact duplicates
+                        pathInfo = ArtifactPathInfo.parse(transfer.getPath() + MAVEN_SUBSTITUTE_EXTENSION);
+                    }
                     if (pathInfo != null) {
                         // See https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#maven
                         PackageURLBuilder purlBuilder = PackageURLBuilder.aPackageURL()

--- a/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportMocks.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportMocks.java
@@ -28,6 +28,9 @@ public class TrackingReportMocks {
             "nottobeignored");
 
     public static String indyPom = "/org/commonjava/indy/indy-core/0.17.0/indy-core-0.17.0.pom";
+    public static String noFileExtensionArtifact = "/org/jboss/shrinkwrap/shrinkwrap-api/1.2.6/shrinkwrap-api-1.2.6";
+    public static String noFileExtensionArtifactIdentifier = "org.jboss.shrinkwrap:shrinkwrap-api:empty:1.2.6";
+    public static String getNoFileExtensionArtifactPurl = "pkg:maven/org.jboss.shrinkwrap/shrinkwrap-api@1.2.6?type=empty";
     public static TrackedContentEntryDTO indyPomFromCentral;
 
     public static String indyJar = "/org/commonjava/indy/indy-core/0.17.0/indy-core-0.17.0.jar";

--- a/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportProcessorTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportProcessorTest.java
@@ -237,6 +237,44 @@ public class TrackingReportProcessorTest {
         Assertions.assertEquals(originPomUrl, artifact.getOriginUrl());
     }
 
+    /**
+     * Test if we properly handle maven urls with no extension and see if the right identifier and purl are generated
+     *
+     * @throws RepositoryDriverException
+     */
+    @Test
+    public void verifyNoFileExtensionArtifacts() throws RepositoryDriverException {
+        // given
+        TrackedContentDTO report = new TrackedContentDTO();
+        Set<TrackedContentEntryDTO> downloads = new HashSet<>();
+
+        String buildContentId = "build-Y";
+        StoreKey buildKey = new StoreKey(PackageTypeConstants.PKG_TYPE_MAVEN, StoreType.hosted, buildContentId);
+
+        // NCL-7238: Handle urls with no file extension
+        TrackedContentEntryDTO trackedNoFileExtensionArtifact = new TrackedContentEntryDTO(
+                buildKey,
+                AccessChannel.NATIVE,
+                TrackingReportMocks.noFileExtensionArtifact);
+        String noFileExtensionUrl = "originNoFileExtensionUrl";
+        trackedNoFileExtensionArtifact.setOriginUrl(noFileExtensionUrl);
+        downloads.add(trackedNoFileExtensionArtifact);
+
+        report.setDownloads(downloads);
+
+        // when
+        List<RepositoryArtifact> artifacts = trackingReportProcessor.collectDownloadedArtifacts(report);
+
+        // then
+        Assertions.assertEquals(1, artifacts.size());
+        RepositoryArtifact artifact = artifacts.stream()
+                .filter(a -> a.getDeployPath().equals(TrackingReportMocks.noFileExtensionArtifact))
+                .filter(a -> a.getIdentifier().equals(TrackingReportMocks.noFileExtensionArtifactIdentifier))
+                .filter(a -> a.getPurl().equals(TrackingReportMocks.getNoFileExtensionArtifactPurl))
+                .findAny()
+                .orElseThrow();
+    }
+
     @Test
     void shouldNotArchiveGenericProxyArtifacts() throws RepositoryDriverException {
         TrackedContentDTO report = new TrackedContentDTO();


### PR DESCRIPTION
In some cases, a Maven build might download something with no file extension. This causes our systems to panic and create duplicates of the downloaded url in our artifact database.

We find existing artifacts in our database using the identifier and sha256 combo to avoid duplicated artifacts for the same artifact. The identifier is different for those download urls with no extensions, and this causes the duplicated artifacts to surface.

This commit attempts to deal with this situation more gracefully by setting the file extension '.empty' for those kind of urls. This makes repository-driver generate predictable identifiers and purl, which in turn prevents the duplicate artifact entries in our database.

A test case is provided that ensures that a url with no extension is handled properly. The existing tests ensure that a url with extension is also handled properly.