### PR TITLE
[NCL-7409] Set artifactQuality for uploads and downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-api</artifactId>
-      <version>2.4.1</version>
+      <version>2.4.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>


### PR DESCRIPTION
It is set to NEW for uploaded artifacts. For downloaded ones it is either NEW for sources ignored from promotion and IMPORTED for everything else.

Follows https://github.com/project-ncl/pnc-api/pull/109