### PR TITLE
Revert to old quarkus 2.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <quarkus-logging-kafka.version>1.0.3</quarkus-logging-kafka.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.13.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <quarkus.package.type>uber-jar</quarkus.package.type>


### PR DESCRIPTION
Fixing issues when releasing the software:

```
[INFO] [ERROR] Repository "orgjbosspnc-1370" failures
[INFO] [ERROR]   Rule "sources-staging" failures
[INFO] [ERROR]     * Missing: no main jar artifact found in folder '/org/jboss/pnc/repository-driver/1.1.9'
[INFO] [ERROR]   Rule "javadoc-staging" failures
[INFO] [ERROR]     * Missing: no main jar artifact found in folder '/org/jboss/pnc/repository-driver/1.1.9'
```