### PR TITLE
Add property to allow release to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,8 @@
         <version>${quarkus.platform.version}</version>
         <configuration>
             <finalName>repository-driver</finalName>
+            <!-- needed to publish to maven central -->
+            <skipOriginalJarRename>true</skipOriginalJarRename>
         </configuration>
         <extensions>true</extensions>
         <executions>


### PR DESCRIPTION
Otherwise staging plugin complains of no main jar found.
See: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Quarkus.20app.20release.20on.20Maven.20Central for more details