### PR TITLE
[NCL-6598] - Configure the promotion process to call the archival service, if needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-common</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>net.jodah</groupId>

--- a/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
@@ -39,7 +39,7 @@ public class Configuration {
     String indyUrl;
 
     @ConfigProperty(name = "repository-driver.archive-service.api-url")
-    String archiveEndpoint;
+    String archiveServiceEndpoint;
 
     @ConfigProperty(name = "repository-driver.indy-client.request-timeout", defaultValue = "30")
     Integer indyClientRequestTimeout;
@@ -107,5 +107,14 @@ public class Configuration {
 
     @ConfigProperty(name = "repository-driver.indy-sidecar.url")
     String sidecarUrl;
+
+    @ConfigProperty(name = "repository-driver.archive-service.running-wait-for", defaultValue = "30")
+    long archiveServiceRunningWaitFor;
+
+    @ConfigProperty(name = "repository-driver.archive-service.running-retry-delay-msec", defaultValue = "500")
+    long archiveServiceRunningRetryDelayMsec;
+
+    @ConfigProperty(name = "repository-driver.archive-service.running-retry-max-delay-msec", defaultValue = "5000")
+    long archiveServiceRunningRetryMaxDelayMsec;
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -71,6 +71,10 @@ repository-driver:
   callback-retry-max-delay-msec: 5000
   archive-service:
     api-url:
+    enabled: false
+    running-wait-for: 60
+    running-retry-delay-msec: 500
+    running-retry-max-delay-msec: 5000
 
 "%test":
   quarkus:

--- a/src/test/java/org/jboss/pnc/repositorydriver/DriverTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/DriverTest.java
@@ -12,10 +12,14 @@ import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.honeycomb.libhoney.shaded.org.apache.http.HttpResponse;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.RestAssured;
+import io.restassured.response.ResponseBodyExtractionOptions;
+
 import org.jboss.pnc.api.constants.HttpHeaders;
 import org.jboss.pnc.api.constants.MDCHeaderKeys;
 import org.jboss.pnc.api.dto.Request;
@@ -153,18 +157,20 @@ public class DriverTest {
 
     @Test
     public void testArchiveRequest() {
-        given().contentType(MediaType.APPLICATION_JSON)
+        ResponseBodyExtractionOptions body = given().contentType(MediaType.APPLICATION_JSON)
                 .headers(requestHeaders())
                 .body(ArchiveRequest.builder().buildConfigId("10").buildContentId("100").build())
                 .when()
                 .post("/archive")
                 .then()
-                .statusCode(204);
+                .statusCode(204)
+                .extract()
+                .body();
 
         verify(
                 1,
-                postRequestedFor(urlEqualTo("/archival"))
-                        .withRequestBody(matchingJsonPath("$.buildConfigId", containing("10"))));
+                postRequestedFor(urlEqualTo("/archive"))
+                        .withRequestBody(matchingJsonPath("buildConfigId", containing("10"))));
     }
 
     public static Map<String, String> requestHeaders() {

--- a/src/test/java/org/jboss/pnc/repositorydriver/testresource/WiremockArchiveServer.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/testresource/WiremockArchiveServer.java
@@ -17,8 +17,8 @@ public class WiremockArchiveServer implements QuarkusTestResourceLifecycleManage
         wiremock = new WireMockServer();
         wiremock.start();
 
-        stubFor(post(urlEqualTo("/archival")).willReturn(aResponse().withStatus(204)));
-        return Collections.singletonMap("repository-driver.archive-service.api-url", wiremock.baseUrl() + "/archival");
+        stubFor(post(urlEqualTo("/archive")).willReturn(aResponse().withStatus(204)));
+        return Collections.singletonMap("repository-driver.archive-service.api-url", wiremock.baseUrl() + "/archive");
     }
 
     @Override


### PR DESCRIPTION
Create a doArchive service to reuse the tracking report if already available, avoiding another call to Indy; improve the requestArchival method to have retries and timeouts, added one manual span context to wrap the call to the archival service; add the call to the archival service (if enabled) after the promotion process