### PR TITLE
[NCL-7614] Set graceful shutdown of 30s

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ quarkus:
           # Send telemetry data to an opentelemetry-collector
           #endpoint: http://localhost:4317
   shutdown:
-    timeout: 300
+    timeout: 30
   log:
     category:
       "org.jboss.pnc":


### PR DESCRIPTION
Openshift waits 30 seconds until it forcefully kills a pod. We should set the quarkus timeout for around the same time period.