### PR TITLE
[NCL-7802] Bump the quarkus-logging-kafka version to fix OOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-logging-kafka.version>1.0.3</quarkus-logging-kafka.version>
+    <quarkus-logging-kafka.version>1.0.5-SNAPSHOT</quarkus-logging-kafka.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>


### PR DESCRIPTION
...when constructing promotion validation error message.