### PR TITLE
[v1.1][NCLSUP-940] bump pnc-api to 2.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-api</artifactId>
-      <version>2.4.5</version>
+      <version>2.4.6</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>


### PR DESCRIPTION
This is needed to fix a JSON serialization / deserialization for the `brewPullActive` field in 'RepositoryCreateRequest.'

Since the getter is `isBrewPullActive`, Jackson (this time!) wrongly assumes that the key to serialize is `brewPullActive` instead of `isBrewPullActive` [1].

On the repository-driver side, it's expecting the key to be 'isBrewPullActive' instead of 'brewPullActive'. This causes brew pull active to always be false as a result.

The fix is to rename `isBrewPullActive` to `brewPullActive` as it should have been from the very beginning.

[1] That decision to choose `isBrewPullActive` was a dumb one from me