### PR TITLE
[NCL-8324] add option to force http1.1 for archive service

### DIFF
--- a/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
@@ -114,6 +114,9 @@ public class Configuration {
     @ConfigProperty(name = "repository-driver.indy-sidecar.archive-enabled", defaultValue = "false")
     boolean sidecarArchiveEnabled;
 
+    @ConfigProperty(name = "repository-driver.archive-service.prefer-http-2", defaultValue = "true")
+    boolean archiveServicePreferHttp2;
+
     @ConfigProperty(name = "repository-driver.archive-service.running-wait-for", defaultValue = "30")
     long archiveServiceRunningWaitFor;
 

--- a/src/main/java/org/jboss/pnc/repositorydriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Driver.java
@@ -87,6 +87,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
 import static org.jboss.pnc.api.constants.HttpHeaders.AUTHORIZATION_STRING;
 import static org.jboss.pnc.api.constants.HttpHeaders.CONTENT_TYPE_STRING;
@@ -467,6 +469,7 @@ public class Driver {
      */
     private HttpRequest getArchivalHttpRequest(String body) {
         HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .version(configuration.isArchiveServicePreferHttp2() ? HTTP_2 : HTTP_1_1)
                 .uri(URI.create(configuration.getArchiveServiceEndpoint()))
                 .POST(HttpRequest.BodyPublishers.ofString(body))
                 .timeout(Duration.ofSeconds(configuration.getHttpClientRequestTimeout()))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,6 +69,7 @@ repository-driver:
   callback-retry-max-delay-msec: 5000
   archive-service:
     api-url:
+    prefer-http-2: true
     running-wait-for: 60
     running-retry-delay-msec: 500
     running-retry-max-delay-msec: 5000


### PR DESCRIPTION
This commit adds a configuration option to modify preferred HTTP protocol for archive-service http requests.