### PR TITLE
[NCLSUP-633] Add checksums to tested artifacts

### DIFF
--- a/src/test/java/org/jboss/pnc/repositorydriver/IndyMock.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/IndyMock.java
@@ -175,8 +175,22 @@ public class IndyMock extends Indy {
             String buildContentId = "build-X";
             StoreKey buildKey = new StoreKey(PackageTypeConstants.PKG_TYPE_MAVEN, StoreType.hosted, buildContentId);
 
-            uploads.add(new TrackedContentEntryDTO(buildKey, AccessChannel.NATIVE, TrackingReportMocks.indyJar));
-            uploads.add(new TrackedContentEntryDTO(buildKey, AccessChannel.NATIVE, TrackingReportMocks.indyPom));
+            TrackedContentEntryDTO indyJarEntry = new TrackedContentEntryDTO(
+                    buildKey,
+                    AccessChannel.NATIVE,
+                    TrackingReportMocks.indyJar);
+            indyJarEntry.setMd5("abc");
+            indyJarEntry.setSha1("abc");
+            indyJarEntry.setSha256("abc");
+            uploads.add(indyJarEntry);
+            TrackedContentEntryDTO indyPomEntry = new TrackedContentEntryDTO(
+                    buildKey,
+                    AccessChannel.NATIVE,
+                    TrackingReportMocks.indyPom);
+            indyPomEntry.setMd5("abc");
+            indyPomEntry.setSha1("abc");
+            indyPomEntry.setSha256("abc");
+            uploads.add(indyPomEntry);
             report.setUploads(uploads);
 
             return report;

--- a/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportMocks.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportMocks.java
@@ -43,6 +43,9 @@ public class TrackingReportMocks {
                 TrackingReportMocks.centralKey,
                 AccessChannel.NATIVE,
                 TrackingReportMocks.indyPom);
+        indyPomFromCentral.setMd5("abc");
+        indyPomFromCentral.setSha1("abc");
+        indyPomFromCentral.setSha256("abc");
         indyPomSha1FromCentral = new TrackedContentEntryDTO(
                 TrackingReportMocks.centralKey,
                 AccessChannel.NATIVE,
@@ -51,6 +54,9 @@ public class TrackingReportMocks {
                 TrackingReportMocks.centralKey,
                 AccessChannel.NATIVE,
                 TrackingReportMocks.indyJar);
+        indyJarFromCentral.setMd5("abc");
+        indyJarFromCentral.setSha1("abc");
+        indyJarFromCentral.setSha256("abc");
         indyJarSha1FromCentral = new TrackedContentEntryDTO(
                 TrackingReportMocks.centralKey,
                 AccessChannel.NATIVE,

--- a/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportProcessorTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportProcessorTest.java
@@ -393,6 +393,9 @@ public class TrackingReportProcessorTest {
         StoreKey storeKey = new StoreKey(PKG_TYPE_GENERIC_HTTP, StoreType.remote, name);
         TrackedContentEntryDTO entry = new TrackedContentEntryDTO(storeKey, AccessChannel.GENERIC_PROXY, path);
         entry.setOriginUrl(originUrl);
+        entry.setMd5("0bee89b07a248e27c83fc3d5951213c1");
+        entry.setSha1("03cfd743661f07975fa2f1220c5194cbaff48451");
+        entry.setSha256("edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb");
         return entry;
     }
 
@@ -400,6 +403,9 @@ public class TrackingReportProcessorTest {
         StoreKey storeKey = new StoreKey(PackageTypeConstants.PKG_TYPE_MAVEN, StoreType.hosted, name);
         TrackedContentEntryDTO entry = new TrackedContentEntryDTO(storeKey, AccessChannel.NATIVE, path);
         entry.setOriginUrl(originUrl);
+        entry.setMd5("0bee89b07a248e27c83fc3d5951213c1");
+        entry.setSha1("03cfd743661f07975fa2f1220c5194cbaff48451");
+        entry.setSha256("edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb");
         return entry;
     }
 }


### PR DESCRIPTION
Related: https://github.com/project-ncl/pnc-api/pull/181

Note, the validation changes in PNC API are in 2.5.0-SNAPSHOT, but I did not update it in this PR, as that version of PNC-API also includes removal of orch logs, which is in weird state.