### PR TITLE
[v1.2.x] Implement a new indy authenticator to use oidcClient

### DIFF
--- a/src/main/java/org/jboss/pnc/repositorydriver/BeanFactory.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/BeanFactory.java
@@ -18,8 +18,6 @@ import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.indy.client.core.Indy;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
-import org.commonjava.indy.client.core.auth.IndyClientAuthenticator;
-import org.commonjava.indy.client.core.auth.OAuth20BearerTokenAuthenticator;
 import org.commonjava.indy.client.core.metric.ClientGoldenSignalsMetricSet;
 import org.commonjava.indy.client.core.metric.ClientTrafficClassifier;
 import org.commonjava.indy.client.core.module.IndyContentClientModule;
@@ -35,10 +33,9 @@ import org.commonjava.o11yphant.metrics.system.StoragePathProvider;
 import org.commonjava.util.jhttpc.model.SiteConfig;
 import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
 import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.pnc.repositorydriver.indy.IndyPNCOAuthBearerAuthenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.quarkus.oidc.client.Tokens;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
@@ -52,7 +49,7 @@ public class BeanFactory {
     Configuration configuration;
 
     @Inject
-    Tokens serviceTokens;
+    IndyPNCOAuthBearerAuthenticator indyPNCOAuthBearerAuthenticator;
 
     protected SiteConfig indySiteConfig;
     protected IndyClientModule[] indyModules;
@@ -103,11 +100,10 @@ public class BeanFactory {
 
     @Produces
     synchronized Indy createIndyServiceAccountClient() {
-        IndyClientAuthenticator authenticator = new OAuth20BearerTokenAuthenticator(serviceTokens.getAccessToken());
         try {
             indy = new Indy(
                     indySiteConfig,
-                    authenticator,
+                    indyPNCOAuthBearerAuthenticator,
                     new IndyObjectMapper(true),
                     MdcUtils.mdcToMapWithHeaderKeys(),
                     indyModules);

--- a/src/main/java/org/jboss/pnc/repositorydriver/indy/IndyPNCOAuthBearerAuthenticator.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/indy/IndyPNCOAuthBearerAuthenticator.java
@@ -1,0 +1,38 @@
+package org.jboss.pnc.repositorydriver.indy;
+
+import io.quarkus.oidc.client.OidcClient;
+import org.apache.http.Header;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.commonjava.indy.client.core.auth.IndyClientAuthenticator;
+import org.commonjava.util.jhttpc.JHttpCException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class IndyPNCOAuthBearerAuthenticator extends IndyClientAuthenticator {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private static final String BEARER_FORMAT = "Bearer %s";
+
+    @Inject
+    OidcClient oidcClient;
+
+    @Override
+    public HttpClientBuilder decorateClientBuilder(HttpClientBuilder builder) throws JHttpCException {
+        builder.addInterceptorFirst((HttpRequestInterceptor) (httpRequest, httpContext) -> {
+            final Header header = new BasicHeader(
+                    AUTHORIZATION_HEADER,
+                    String.format(BEARER_FORMAT, getFreshAccessToken()));
+            httpRequest.addHeader(header);
+        });
+        return builder;
+    }
+
+    private String getFreshAccessToken() {
+        return oidcClient.getTokens().await().indefinitely().getAccessToken();
+    }
+}

--- a/src/test/java/org/jboss/pnc/repositorydriver/BeanFactoryMock.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/BeanFactoryMock.java
@@ -9,7 +9,6 @@ import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.client.core.auth.IndyClientAuthenticator;
 import org.commonjava.indy.client.core.auth.OAuth20BearerTokenAuthenticator;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
-import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +25,7 @@ public class BeanFactoryMock extends BeanFactory {
         IndyClientModule[] indyModules = new IndyClientModule[] { new IndyMock.IndyFoloAdminClientModuleMock(),
                 new IndyMock.IndyFoloContentClientModuleMock(), new IndyMock.IndyPromoteClientModuleMock() };
 
-        IndyClientAuthenticator authenticator = new OAuth20BearerTokenAuthenticator(serviceTokens.getAccessToken());
+        IndyClientAuthenticator authenticator = new OAuth20BearerTokenAuthenticator("hello");
         try {
             indy = new IndyMock(
                     indySiteConfig,


### PR DESCRIPTION
This is done so that we use a fresh token for Indy on every request.