### PR TITLE
Get jupiter-params version from quarkus parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Rather than hardcoding a specific value