### PR TITLE
Bump version to 3.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jboss.pnc</groupId>
   <artifactId>repository-driver</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
 
   <name>repository driver</name>
   <description>Artifact repository driver</description>


### PR DESCRIPTION
Version bumping to 3.5.0, so that it's aligned with most of PNC components.