### PR TITLE
[NCL-9785] Ability to specify promo target based on build category

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-api</artifactId>
-      <version>3.5.0</version>
+      <version>3.5.1-SNAPSHOT</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>

--- a/src/main/java/org/jboss/pnc/repositorydriver/BuildGroupBuilder.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/BuildGroupBuilder.java
@@ -1,8 +1,6 @@
 package org.jboss.pnc.repositorydriver;
 
 import static org.jboss.pnc.repositorydriver.Driver.GRADLE_PLUGINS_REPO;
-import static org.jboss.pnc.repositorydriver.constants.IndyRepositoryConstants.COMMON_BUILD_GROUP_CONSTITUENTS_GROUP;
-import static org.jboss.pnc.repositorydriver.constants.IndyRepositoryConstants.TEMPORARY_BUILDS_GROUP;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -20,6 +18,7 @@ import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.core.dto.StoreListingDTO;
+import org.jboss.pnc.api.enums.BuildCategory;
 import org.jboss.pnc.api.enums.BuildType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +33,7 @@ public class BuildGroupBuilder {
 
     private static final Logger userLog = LoggerFactory.getLogger("org.jboss.pnc._userlog_.repository-driver");
 
+    private Configuration configuration;
     private Indy indy;
     private Group buildGroup;
     private String packageType;
@@ -43,8 +43,13 @@ public class BuildGroupBuilder {
     private BuildGroupBuilder() {
     }
 
-    public static BuildGroupBuilder builder(Indy indy, String packageType, String buildContentId) {
+    public static BuildGroupBuilder builder(
+            Configuration configuration,
+            Indy indy,
+            String packageType,
+            String buildContentId) {
         BuildGroupBuilder buildGroupBuilder = new BuildGroupBuilder();
+        buildGroupBuilder.configuration = configuration;
         buildGroupBuilder.indy = indy;
         buildGroupBuilder.packageType = packageType;
         buildGroupBuilder.buildContentId = buildContentId;
@@ -74,12 +79,30 @@ public class BuildGroupBuilder {
      *
      * @param buildType the build type
      */
-    public BuildGroupBuilder addGlobalConstituents(BuildType buildType, boolean tempBuild) {
+    public BuildGroupBuilder addGlobalConstituents(
+            BuildType buildType,
+            BuildCategory buildCategory,
+            boolean tempBuild) {
         // 1. global builds artifacts
         if (tempBuild) {
-            buildGroup.addConstituent(new StoreKey(packageType, StoreType.hosted, TEMPORARY_BUILDS_GROUP));
+            for (String hostedTempConstituent : configuration.getBuildGroupConstituentsTempHosted(buildCategory)
+                    .orElse(List.of())) {
+                buildGroup.addConstituent(new StoreKey(packageType, StoreType.hosted, hostedTempConstituent));
+            }
+            for (String groupTempConstituent : configuration.getBuildGroupConstituentsTempGroup(buildCategory)
+                    .orElse(List.of())) {
+                buildGroup.addConstituent(new StoreKey(packageType, StoreType.group, groupTempConstituent));
+            }
+        } else {
+            for (String hostedConstituent : configuration.getBuildGroupConstituentsHosted(buildCategory)
+                    .orElse(List.of())) {
+                buildGroup.addConstituent(new StoreKey(packageType, StoreType.hosted, hostedConstituent));
+            }
+            for (String groupConstituent : configuration.getBuildGroupConstituentsGroup(buildCategory)
+                    .orElse(List.of())) {
+                buildGroup.addConstituent(new StoreKey(packageType, StoreType.group, groupConstituent));
+            }
         }
-        buildGroup.addConstituent(new StoreKey(packageType, StoreType.group, COMMON_BUILD_GROUP_CONSTITUENTS_GROUP));
 
         // add build-type-specific constituents
         switch (buildType) {

--- a/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
@@ -24,7 +24,10 @@ import java.util.Optional;
 import jakarta.enterprise.context.Dependent;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.pnc.api.enums.BuildCategory;
 
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.SmallRyeConfig;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,6 +35,8 @@ import lombok.Setter;
 @Setter
 @Dependent
 public class Configuration {
+    private static final SmallRyeConfig CONFIG_READ = org.eclipse.microprofile.config.ConfigProvider.getConfig()
+            .unwrap(SmallRyeConfig.class);
 
     @ConfigProperty(name = "repository-driver.self-base-url")
     String selfBaseUrl;
@@ -74,12 +79,6 @@ public class Configuration {
 
     @ConfigProperty(name = "repository-driver.keycloak.request-timeout", defaultValue = "PT10S")
     Duration keyCloakRequestTimeout;
-
-    @ConfigProperty(name = "repository-driver.build-promotion-target")
-    String buildPromotionTarget;
-
-    @ConfigProperty(name = "repository-driver.temp-build-promotion-target")
-    String tempBuildPromotionTarget;
 
     @ConfigProperty(name = "repository-driver.ignored-repo-patterns.archive")
     Optional<List<String>> ignoredRepoPatternsArchive;
@@ -133,4 +132,87 @@ public class Configuration {
     @ConfigProperty(name = "repository-driver.heartbeat.interval", defaultValue = "5")
     long heartbeatInterval;
 
+    private static String getBuildCategoryConfig(String category, String leafConfig) {
+        return "repository-driver.build-categories." + category + "." + leafConfig;
+    }
+
+    /**
+     * get the config value for buildcategory. if no values specified for that buildcategory, use the 'default' one
+     * 
+     * @param buildCategory
+     * @param leafConfig
+     * @return
+     */
+    private String getConfigString(BuildCategory buildCategory, String leafConfig) {
+
+        if (buildCategory == null) {
+            // fallback if buildCategory is null
+            buildCategory = BuildCategory.STANDARD;
+        }
+
+        String buildCategoryConfig = getBuildCategoryConfig(buildCategory.name().toLowerCase(), leafConfig);
+        String defaultBuildCategoryConfig = getBuildCategoryConfig("default", leafConfig);
+
+        ConfigValue configValue = CONFIG_READ.getConfigValue(buildCategoryConfig);
+
+        if (configValue.getValue() == null) {
+            // if the raw value is null, assume that that config was never specified
+            // get the default value instead
+            return CONFIG_READ.getOptionalValue(defaultBuildCategoryConfig, String.class).orElse(null);
+        } else {
+            return configValue.getValue();
+        }
+    }
+
+    /**
+     * get the config value list for buildcategory. if no values specified for that buildcategory, use the 'default' one
+     * 
+     * @param buildCategory
+     * @param leafConfig
+     * @return
+     */
+    private Optional<List<String>> getConfigListString(BuildCategory buildCategory, String leafConfig) {
+
+        if (buildCategory == null) {
+            // fallback if buildCategory is null
+            buildCategory = BuildCategory.STANDARD;
+        }
+
+        String buildCategoryConfig = getBuildCategoryConfig(buildCategory.name().toLowerCase(), leafConfig);
+        String defaultBuildCategoryConfig = getBuildCategoryConfig("default", leafConfig);
+
+        ConfigValue configValue = CONFIG_READ.getConfigValue(buildCategoryConfig);
+
+        if (configValue.getValue() == null) {
+            // if the raw value is null, assume that that config was never specified
+            // get the default value instead
+            return CONFIG_READ.getOptionalValues(defaultBuildCategoryConfig, String.class);
+        } else {
+            return CONFIG_READ.getOptionalValues(buildCategoryConfig, String.class);
+        }
+    }
+
+    public String getBuildPromotionTarget(BuildCategory buildCategory) {
+        return getConfigString(buildCategory, "build-promotion-target");
+    }
+
+    public String getTempBuildPromotionTarget(BuildCategory buildCategory) {
+        return getConfigString(buildCategory, "temp-build-promotion-target");
+    }
+
+    public Optional<List<String>> getBuildGroupConstituentsTempHosted(BuildCategory buildCategory) {
+        return getConfigListString(buildCategory, "build-group-constituents.temp-hosted");
+    }
+
+    public Optional<List<String>> getBuildGroupConstituentsTempGroup(BuildCategory buildCategory) {
+        return getConfigListString(buildCategory, "build-group-constituents.temp-group");
+    }
+
+    public Optional<List<String>> getBuildGroupConstituentsHosted(BuildCategory buildCategory) {
+        return getConfigListString(buildCategory, "build-group-constituents.hosted");
+    }
+
+    public Optional<List<String>> getBuildGroupConstituentsGroup(BuildCategory buildCategory) {
+        return getConfigListString(buildCategory, "build-group-constituents.group");
+    }
 }

--- a/src/main/java/org/jboss/pnc/repositorydriver/Driver.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Driver.java
@@ -159,6 +159,7 @@ public class Driver {
                 setupBuildRepos(
                         repositoryCreateRequest.getBuildContentId(),
                         buildType,
+                        repositoryCreateRequest.getBuildCategory(),
                         packageType,
                         repositoryCreateRequest.isTempBuild(),
                         repositoryCreateRequest.isBrewPullActive(),
@@ -236,6 +237,7 @@ public class Driver {
         String buildContentId = promoteRequest.getBuildContentId();
         String buildConfigurationId = promoteRequest.getBuildConfigurationId();
         BuildType buildType = promoteRequest.getBuildType();
+        BuildCategory buildCategory = promoteRequest.getBuildCategory();
         TrackedContentDTO report;
         try {
             report = retrieveTrackingReport(buildContentId);
@@ -276,7 +278,7 @@ public class Driver {
                     uploadedArtifacts = trackingReportProcessor.collectUploadedArtifacts(
                             report,
                             promoteRequest.isTempBuild(),
-                            promoteRequest.getBuildCategory());
+                            buildCategory);
                 } catch (RepositoryDriverException e) {
                     String message = "Failed collecting downloaded or uploaded artifacts: ";
                     userLog.error(message, e);
@@ -297,6 +299,7 @@ public class Driver {
                                     report,
                                     promoteRequest.isTempBuild(),
                                     buildType.getRepoType(),
+                                    buildCategory,
                                     buildContentId),
                             promoteRequest.isTempBuild(),
                             buildContentId);
@@ -650,6 +653,7 @@ public class Driver {
     private void setupBuildRepos(
             String buildContentId,
             BuildType buildType,
+            BuildCategory buildCategory,
             String packageType,
             boolean tempBuild,
             boolean brewPullActive,
@@ -693,7 +697,7 @@ public class Driver {
         storesModule.create(buildArtifacts, logCreatingHostedRepo, HostedRepository.class);
 
         // create build group
-        Group buildGroup = BuildGroupBuilder.builder(indy, packageType, buildContentId)
+        Group buildGroup = BuildGroupBuilder.builder(configuration, indy, packageType, buildContentId)
                 .withDescription(
                         String.format(
                                 "Aggregation group for PNC %s build #%s",
@@ -702,7 +706,7 @@ public class Driver {
                 // build-local artifacts
                 .addConstituent(hostedKey)
                 // Global-level repos, for captured/shared artifacts and access to the outside world
-                .addGlobalConstituents(buildType, tempBuild)
+                .addGlobalConstituents(buildType, buildCategory, tempBuild)
                 // build-specific repos
                 .addExtraConstituents(extraDependencyRepositories)
                 // brew pull: see MMENG-1262

--- a/src/main/java/org/jboss/pnc/repositorydriver/TrackingReportProcessor.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/TrackingReportProcessor.java
@@ -223,7 +223,7 @@ public class TrackingReportProcessor {
 
                 logger.info("Recording upload: {}", identifier);
                 RepositoryType repoType = TypeConverters.toRepoType(storeKey.getPackageType());
-                TargetRepository targetRepository = getUploadsTargetRepository(repoType, tempBuild);
+                TargetRepository targetRepository = getUploadsTargetRepository(repoType, buildCategory, tempBuild);
 
                 RepositoryArtifact artifact = RepositoryArtifact.builder()
                         .md5(upload.getMd5())
@@ -311,6 +311,7 @@ public class TrackingReportProcessor {
             @SpanAttribute(value = "report") TrackedContentDTO report,
             @SpanAttribute(value = "tempBuild") boolean tempBuild,
             @SpanAttribute(value = "repositoryType") RepositoryType repositoryType,
+            @SpanAttribute(value = "buildCategory") BuildCategory buildCategory,
             @SpanAttribute(value = "buildContentId") String buildContentId) {
         PromotionPaths promotionPaths = new PromotionPaths();
         Set<TrackedContentEntryDTO> uploads = report.getUploads();
@@ -322,7 +323,10 @@ public class TrackingReportProcessor {
             if (artifactFilterPromotion.accepts(upload)) {
                 String packageType = TypeConverters.getIndyPackageTypeKey(repositoryType);
                 StoreKey source = new StoreKey(packageType, StoreType.hosted, buildContentId);
-                StoreKey target = new StoreKey(packageType, StoreType.hosted, getBuildPromotionTarget(tempBuild));
+                StoreKey target = new StoreKey(
+                        packageType,
+                        StoreType.hosted,
+                        getBuildPromotionTarget(buildCategory, tempBuild));
                 promotionPaths.add(source, target, path);
             }
         }
@@ -634,16 +638,19 @@ public class TrackingReportProcessor {
         return artifact;
     }
 
-    private TargetRepository getUploadsTargetRepository(RepositoryType repoType, boolean tempBuild)
+    private TargetRepository getUploadsTargetRepository(
+            RepositoryType repoType,
+            BuildCategory buildCategory,
+            boolean tempBuild)
             throws RepositoryDriverException {
 
         StoreKey storeKey;
         String identifier;
         if (repoType == RepositoryType.MAVEN) {
-            storeKey = new StoreKey(MAVEN_PKG_KEY, StoreType.hosted, getBuildPromotionTarget(tempBuild));
+            storeKey = new StoreKey(MAVEN_PKG_KEY, StoreType.hosted, getBuildPromotionTarget(buildCategory, tempBuild));
             identifier = ReposiotryIdentifier.INDY_MAVEN;
         } else if (repoType == RepositoryType.NPM) {
-            storeKey = new StoreKey(NPM_PKG_KEY, StoreType.hosted, getBuildPromotionTarget(tempBuild));
+            storeKey = new StoreKey(NPM_PKG_KEY, StoreType.hosted, getBuildPromotionTarget(buildCategory, tempBuild));
             identifier = ReposiotryIdentifier.INDY_NPM;
         } else {
             throw new RepositoryDriverException(
@@ -670,8 +677,9 @@ public class TrackingReportProcessor {
         return promotionTargetsCache.get(packageType);
     }
 
-    private String getBuildPromotionTarget(boolean tempBuild) {
-        return tempBuild ? configuration.getTempBuildPromotionTarget() : configuration.getBuildPromotionTarget();
+    private String getBuildPromotionTarget(BuildCategory buildCategory, boolean tempBuild) {
+        return tempBuild ? configuration.getTempBuildPromotionTarget(buildCategory)
+                : configuration.getBuildPromotionTarget(buildCategory);
     }
 
     /**

--- a/src/main/java/org/jboss/pnc/repositorydriver/constants/IndyRepositoryConstants.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/constants/IndyRepositoryConstants.java
@@ -22,12 +22,6 @@ package org.jboss.pnc.repositorydriver.constants;
  */
 public class IndyRepositoryConstants {
 
-    /** Name of group that contains common builds groups' constituents. */
-    public static final String COMMON_BUILD_GROUP_CONSTITUENTS_GROUP = "builds-untested+shared-imports+public";
-
-    /** Name of repository used to access all previous temporary build outputs. */
-    public static final String TEMPORARY_BUILDS_GROUP = "temporary-builds";
-
     /** Name of hosted repository used to store artifacts from external sources. */
     public static final String SHARED_IMPORTS_ID = "shared-imports";
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,6 +67,21 @@ pnc_client_auth:
   #    path: /mnt/secrets/ldap_credentials # file must be in format: <username>:<password>
 
 repository-driver:
+  # Build Category Configuration
+  build-categories:
+    # Default category
+    default:
+      build-promotion-target: pnc-builds
+      temp-build-promotion-target: temporary-builds
+      build-group-constituents:
+        temp-hosted:
+          - temporary-builds
+        temp-group:
+          - builds-untested+shared-imports+public
+        hosted: [] # deliberately left empty
+        group:
+          - builds-untested+shared-imports+public
+
   ignored-path-patterns:
     archive:
       maven:
@@ -81,8 +96,6 @@ repository-driver:
   ignored-repo-patterns:
     promotion:
     archive:
-  temp-build-promotion-target:
-  build-promotion-target:
   self-base-url:
   indy-client:
     api-url:
@@ -127,8 +140,43 @@ repository-driver:
     http-client:
       connect-timeout: 1
       request-timeout: 3
-    build-promotion-target: "build-target"
-    temp-build-promotion-target: "temp-target"
+
+    # Build Category Configuration
+    build-categories:
+      # Default category
+      default:
+        build-promotion-target: target
+        temp-build-promotion-target: temporary-target
+        build-group-constituents:
+          temp-hosted:
+            - constituent-temp-hosted
+          temp-group:
+            - constituent-temp-group
+          hosted:
+            - consituent-hosted
+          group:
+            - constituent-group
+
+      # Standard category
+      standard:
+        build-group-constituents:
+          temp-hosted:
+            - temp-central
+          temp-group: []
+          hosted:
+            - central
+
+      # Service category
+      service:
+        build-promotion-target: service-builds
+        temp-build-promotion-target: temporary-service-builds
+        build-group-constituents:
+          temp-hosted:
+            - central
+          temp-group: []
+          hosted:
+            - central
+          group: []
     ignored-path-patterns:
       archive:
         maven: [".*/maven-metadata\\.xml(\\..+)?$"]

--- a/src/test/java/org/jboss/pnc/repositorydriver/BuildGroupBuilderTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/BuildGroupBuilderTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.inject.Inject;
+
 import org.commonjava.indy.client.core.Indy;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.module.IndyStoresClientModule;
@@ -18,10 +20,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import io.quarkus.test.junit.QuarkusTest;
+
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
+@QuarkusTest
 public class BuildGroupBuilderTest {
+
+    @Inject
+    Configuration configuration;
 
     @Test
     public void shouldAddExtraRepositoryToBuildGroup() throws IndyClientException {
@@ -38,7 +46,8 @@ public class BuildGroupBuilderTest {
         List<String> repositories = new ArrayList<>();
         repositories.add("http://test.com/maven");
         repositories.add("invalid url"); // should not be added
-        Group buildGroup = BuildGroupBuilder.builder(indy, MavenPackageTypeDescriptor.MAVEN_PKG_KEY, "build-X")
+        Group buildGroup = BuildGroupBuilder
+                .builder(configuration, indy, MavenPackageTypeDescriptor.MAVEN_PKG_KEY, "build-X")
                 .addExtraConstituents(repositories)
                 .build();
 

--- a/src/test/java/org/jboss/pnc/repositorydriver/ConfigurationTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/ConfigurationTest.java
@@ -1,0 +1,69 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.repositorydriver;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.jboss.pnc.api.enums.BuildCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@DisplayName("Configuration Tests")
+public class ConfigurationTest {
+
+    @Inject
+    Configuration configuration;
+
+    @Test
+    @DisplayName("Should have read build category promotion properly and use default as fallback")
+    void testBuildCategoryTempBuildPromotionTarget() {
+
+        // standard doesn't define the temp build, should fall back to default
+        assertEquals("temporary-target", configuration.getTempBuildPromotionTarget(BuildCategory.STANDARD));
+        assertEquals("target", configuration.getBuildPromotionTarget(BuildCategory.STANDARD));
+
+        // service does define the promotion values, should use them
+        assertEquals("temporary-service-builds", configuration.getTempBuildPromotionTarget(BuildCategory.SERVICE));
+        assertEquals("service-builds", configuration.getBuildPromotionTarget(BuildCategory.SERVICE));
+    }
+
+    @Test
+    void testBuildGroupConstituents() {
+        // defined in standard as empty list
+        assertEquals(Optional.empty(), configuration.getBuildGroupConstituentsTempGroup(BuildCategory.STANDARD));
+
+        // defined as 'temp-central' in standard
+        assertEquals(
+                Optional.of(List.of("temp-central")),
+                configuration.getBuildGroupConstituentsTempHosted(BuildCategory.STANDARD));
+
+        // not defined in 'central'; should use default
+        assertEquals(
+                Optional.of(List.of("constituent-group")),
+                configuration.getBuildGroupConstituentsGroup(BuildCategory.STANDARD));
+    }
+
+}

--- a/src/test/java/org/jboss/pnc/repositorydriver/DriverTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/DriverTest.java
@@ -105,6 +105,7 @@ public class DriverTest {
         RepositoryCreateRequest request = RepositoryCreateRequest.builder()
                 .buildContentId("build-X")
                 .buildType(BuildType.MVN)
+                .buildCategory(BuildCategory.STANDARD)
                 .tempBuild(false)
                 .build();
         // when

--- a/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportProcessorTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/TrackingReportProcessorTest.java
@@ -91,7 +91,8 @@ public class TrackingReportProcessorTest {
         StoreKey promotedBuildsKey = new StoreKey(
                 PackageTypeConstants.PKG_TYPE_MAVEN,
                 StoreType.hosted,
-                tempBuild ? configuration.getTempBuildPromotionTarget() : configuration.getBuildPromotionTarget());
+                tempBuild ? configuration.getTempBuildPromotionTarget(BuildCategory.STANDARD)
+                        : configuration.getBuildPromotionTarget(BuildCategory.STANDARD));
 
         uploads.add(new TrackedContentEntryDTO(buildKey, AccessChannel.NATIVE, TrackingReportMocks.indyJar));
         uploads.add(new TrackedContentEntryDTO(buildKey, AccessChannel.NATIVE, TrackingReportMocks.indyJar + ".md5"));
@@ -103,7 +104,12 @@ public class TrackingReportProcessorTest {
 
         // when
         PromotionPaths promotionPaths = trackingReportProcessor
-                .collectUploadsPromotions(report, tempBuild, RepositoryType.MAVEN, buildContentId);
+                .collectUploadsPromotions(
+                        report,
+                        tempBuild,
+                        RepositoryType.MAVEN,
+                        BuildCategory.STANDARD,
+                        buildContentId);
         Set<SourceTargetPaths> sourceTargetPaths = promotionPaths.getSourceTargetsPaths();
 
         // then

--- a/src/test/java/org/jboss/pnc/repositorydriver/WithSidecarTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/WithSidecarTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.any;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
 
+import org.jboss.pnc.api.enums.BuildCategory;
 import org.jboss.pnc.api.enums.BuildType;
 import org.jboss.pnc.api.repositorydriver.dto.RepositoryCreateRequest;
 import org.jboss.pnc.api.repositorydriver.dto.RepositoryCreateResponse;
@@ -51,6 +52,7 @@ public class WithSidecarTest {
         RepositoryCreateRequest request = RepositoryCreateRequest.builder()
                 .buildContentId("build-X")
                 .buildType(BuildType.MVN)
+                .buildCategory(BuildCategory.STANDARD)
                 .tempBuild(false)
                 .build();
         configuration.setSidecarEnabled(true);


### PR DESCRIPTION
Configuration driving the changes
=================================
This is driven by the new lightwell build category which requires us to specify a specific promotion target and build-group-consituents. With that in mind, this commit refactors the configuration so that we switch from global:

```yaml
repository-driver:
    temp-build-promotion-target: temp-hello
    build-promotion-target: hello
```

to:

```yaml
repository-driver:

  # Build Category Configuration
  build-categories:

    # Default category
    default:
      build-promotion-target: hello
      temp-build-promotion-target: temp-hello
      build-group-constituents:
        temp-hosted:
          - temporary-builds
        temp-group:
          - builds-untested+shared-imports+public
        hosted: [] # deliberately left empty
        group:
          - builds-untested+shared-imports+public

    lightwell:
      build-promotion-target: light
      temp-build-promotion-target: temp-light
      build-group-constituents:
        temp-hosted:
          - temp-light
        temp-group: []
        hosted: light
        group: []
```

The `default` category will be use for fallback value if there are no key specified in the specific build-category.

Besides the target, we can now specify the build group constituents for hosted and group repositories. Two Indy repositories are created for a build: a hosted-build and a build-group repository. The build-group repository can then have the items in the `build-group-constituents` added to it.

Before, they were hardcoded. Now they are configurable in our config file.

The default `src/main/application.yaml` provided should match what was previously hardcoded in the source code.

Source code changes
===================
With the configuration change done, we now:

- accept a 'buildCategory' in the `RepoqitoryCreateRequest` DTO to influence what we will use for the promo target and build-group-constituents.
- have to propagate the buildCategory through various files to make it happen
- write tests to make sure the configuration fallbacks to 'default' works
- update existing tests where necessary for the 'buildCategory'