### PR TITLE
[NCL-9834] Bump pnc-api to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-api</artifactId>
-      <version>3.5.1</version>
+      <version>3.5.2</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is to get LIGHTWELL_NOVEL build category