### PR TITLE
Make BuildGroupConstituent flexible

### DIFF
--- a/src/main/java/org/jboss/pnc/repositorydriver/BuildGroupBuilder.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/BuildGroupBuilder.java
@@ -85,22 +85,14 @@ public class BuildGroupBuilder {
             boolean tempBuild) {
         // 1. global builds artifacts
         if (tempBuild) {
-            for (String hostedTempConstituent : configuration.getBuildGroupConstituentsTempHosted(buildCategory)
+            for (Configuration.BuildGroupConstituent temp : configuration.getBuildGroupConstituentsTemp(buildCategory)
                     .orElse(List.of())) {
-                buildGroup.addConstituent(new StoreKey(packageType, StoreType.hosted, hostedTempConstituent));
-            }
-            for (String groupTempConstituent : configuration.getBuildGroupConstituentsTempGroup(buildCategory)
-                    .orElse(List.of())) {
-                buildGroup.addConstituent(new StoreKey(packageType, StoreType.group, groupTempConstituent));
+                buildGroup.addConstituent(new StoreKey(packageType, temp.storeType(), temp.name()));
             }
         } else {
-            for (String hostedConstituent : configuration.getBuildGroupConstituentsHosted(buildCategory)
+            for (Configuration.BuildGroupConstituent permanent : configuration.getBuildGroupConstituents(buildCategory)
                     .orElse(List.of())) {
-                buildGroup.addConstituent(new StoreKey(packageType, StoreType.hosted, hostedConstituent));
-            }
-            for (String groupConstituent : configuration.getBuildGroupConstituentsGroup(buildCategory)
-                    .orElse(List.of())) {
-                buildGroup.addConstituent(new StoreKey(packageType, StoreType.group, groupConstituent));
+                buildGroup.addConstituent(new StoreKey(packageType, permanent.storeType(), permanent.name()));
             }
         }
 

--- a/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
+++ b/src/main/java/org/jboss/pnc/repositorydriver/Configuration.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import jakarta.enterprise.context.Dependent;
 
+import org.commonjava.indy.model.core.StoreType;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.pnc.api.enums.BuildCategory;
 
@@ -35,6 +36,10 @@ import lombok.Setter;
 @Setter
 @Dependent
 public class Configuration {
+
+    public record BuildGroupConstituent(StoreType storeType, String name) {
+    }
+
     private static final SmallRyeConfig CONFIG_READ = org.eclipse.microprofile.config.ConfigProvider.getConfig()
             .unwrap(SmallRyeConfig.class);
 
@@ -138,7 +143,7 @@ public class Configuration {
 
     /**
      * get the config value for buildcategory. if no values specified for that buildcategory, use the 'default' one
-     * 
+     *
      * @param buildCategory
      * @param leafConfig
      * @return
@@ -166,12 +171,14 @@ public class Configuration {
 
     /**
      * get the config value list for buildcategory. if no values specified for that buildcategory, use the 'default' one
-     * 
+     *
      * @param buildCategory
      * @param leafConfig
      * @return
      */
-    private Optional<List<String>> getConfigListString(BuildCategory buildCategory, String leafConfig) {
+    private Optional<List<BuildGroupConstituent>> getConfigListBuildGroupConstituent(
+            BuildCategory buildCategory,
+            String leafConfig) {
 
         if (buildCategory == null) {
             // fallback if buildCategory is null
@@ -183,12 +190,28 @@ public class Configuration {
 
         ConfigValue configValue = CONFIG_READ.getConfigValue(buildCategoryConfig);
 
+        Optional<List<String>> constituents;
         if (configValue.getValue() == null) {
             // if the raw value is null, assume that that config was never specified
             // get the default value instead
-            return CONFIG_READ.getOptionalValues(defaultBuildCategoryConfig, String.class);
+            constituents = CONFIG_READ.getOptionalValues(defaultBuildCategoryConfig, String.class);
         } else {
-            return CONFIG_READ.getOptionalValues(buildCategoryConfig, String.class);
+            constituents = CONFIG_READ.getOptionalValues(buildCategoryConfig, String.class);
+        }
+
+        if (constituents.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(constituents.get().stream().map(value -> {
+                // the constituent is in format <storeType>:<name>
+                String[] storeTypeAndName = value.split(":");
+                if (storeTypeAndName.length != 2) {
+                    throw new RuntimeException(
+                            "Constituent " + value + " format is wrong. It should be <storeType>:<name>");
+                }
+                return new BuildGroupConstituent(StoreType.valueOf(storeTypeAndName[0]), storeTypeAndName[1]);
+            }).toList());
+
         }
     }
 
@@ -200,19 +223,11 @@ public class Configuration {
         return getConfigString(buildCategory, "temp-build-promotion-target");
     }
 
-    public Optional<List<String>> getBuildGroupConstituentsTempHosted(BuildCategory buildCategory) {
-        return getConfigListString(buildCategory, "build-group-constituents.temp-hosted");
+    public Optional<List<BuildGroupConstituent>> getBuildGroupConstituentsTemp(BuildCategory buildCategory) {
+        return getConfigListBuildGroupConstituent(buildCategory, "build-group-constituents.temp");
     }
 
-    public Optional<List<String>> getBuildGroupConstituentsTempGroup(BuildCategory buildCategory) {
-        return getConfigListString(buildCategory, "build-group-constituents.temp-group");
-    }
-
-    public Optional<List<String>> getBuildGroupConstituentsHosted(BuildCategory buildCategory) {
-        return getConfigListString(buildCategory, "build-group-constituents.hosted");
-    }
-
-    public Optional<List<String>> getBuildGroupConstituentsGroup(BuildCategory buildCategory) {
-        return getConfigListString(buildCategory, "build-group-constituents.group");
+    public Optional<List<BuildGroupConstituent>> getBuildGroupConstituents(BuildCategory buildCategory) {
+        return getConfigListBuildGroupConstituent(buildCategory, "build-group-constituents.permanent");
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,13 +74,11 @@ repository-driver:
       build-promotion-target: pnc-builds
       temp-build-promotion-target: temporary-builds
       build-group-constituents:
-        temp-hosted:
-          - temporary-builds
-        temp-group:
-          - builds-untested+shared-imports+public
-        hosted: [] # deliberately left empty
-        group:
-          - builds-untested+shared-imports+public
+        temp:
+          - hosted:temporary-builds
+          - group:builds-untested+shared-imports+public
+        permanent:
+          - group:builds-untested+shared-imports+public
 
   ignored-path-patterns:
     archive:
@@ -148,35 +146,30 @@ repository-driver:
         build-promotion-target: target
         temp-build-promotion-target: temporary-target
         build-group-constituents:
-          temp-hosted:
-            - constituent-temp-hosted
-          temp-group:
-            - constituent-temp-group
-          hosted:
-            - consituent-hosted
-          group:
-            - constituent-group
+          temp:
+            - hosted:constituent-temp-hosted
+            - group:constituent-temp-group
+          permanent:
+            - hosted:consituent-hosted
+            - group:constituent-group
 
       # Standard category
       standard:
         build-group-constituents:
-          temp-hosted:
-            - temp-central
-          temp-group: []
-          hosted:
-            - central
+          temp:
+            - hosted:temp-central
+          permanent:
+            - group:central
 
       # Service category
       service:
         build-promotion-target: service-builds
         temp-build-promotion-target: temporary-service-builds
         build-group-constituents:
-          temp-hosted:
-            - central
-          temp-group: []
-          hosted:
-            - central
-          group: []
+          temp:
+            - hosted:temp-central
+          permanent:
+            - hosted:central
     ignored-path-patterns:
       archive:
         maven: [".*/maven-metadata\\.xml(\\..+)?$"]

--- a/src/test/java/org/jboss/pnc/repositorydriver/ConfigurationTest.java
+++ b/src/test/java/org/jboss/pnc/repositorydriver/ConfigurationTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import jakarta.inject.Inject;
 
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.api.enums.BuildCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,17 +54,13 @@ public class ConfigurationTest {
     @Test
     void testBuildGroupConstituents() {
         // defined in standard as empty list
-        assertEquals(Optional.empty(), configuration.getBuildGroupConstituentsTempGroup(BuildCategory.STANDARD));
-
-        // defined as 'temp-central' in standard
         assertEquals(
-                Optional.of(List.of("temp-central")),
-                configuration.getBuildGroupConstituentsTempHosted(BuildCategory.STANDARD));
+                Optional.of(List.of(new Configuration.BuildGroupConstituent(StoreType.hosted, "temp-central"))),
+                configuration.getBuildGroupConstituentsTemp(BuildCategory.STANDARD));
 
-        // not defined in 'central'; should use default
         assertEquals(
-                Optional.of(List.of("constituent-group")),
-                configuration.getBuildGroupConstituentsGroup(BuildCategory.STANDARD));
+                Optional.of(List.of(new Configuration.BuildGroupConstituent(StoreType.group, "central"))),
+                configuration.getBuildGroupConstituents(BuildCategory.STANDARD));
     }
 
 }


### PR DESCRIPTION
A build group constituent is a repository which is added to the Indy build group created for a build. That Indy build group is then used to resolve dependencies.

For a particular BuildCategory, we always prioritized the hosted repositories over the group repositories for the build group constituent.

This commit allows more flexibility by specifying the order of priority in a single list, where the members can be a hosted, group, remote repository (See `StoreType` for the potential values).

The config changes from:
```yaml
build-categories:
    standard:
        build-group-constituents:
            temp-hosted:
            - temp-value
            temp-group:
            - temp-group
            hosted:
            - hosted-value
            group:
            - group-value
```

to:

```yaml
build-categories:
    standard:
        build-group-constituents:
            temp:
            - hosted:temp-value
            - group:temp-group
            permanent:
            - hosted:hosted-value
            - group:group-value
```

Now we can also put an Indy group on top of the priority list if desired, rather than always prioritizing the hosted repositories before.